### PR TITLE
Add nested mutation example

### DIFF
--- a/services/products/schema.graphql
+++ b/services/products/schema.graphql
@@ -3,6 +3,11 @@ extend type User @key(fields: "id") {
   productsCreated: [Product]
 }
 
+extend type MutatingUser @key(fields: "id") {
+  id: ID! @external
+  withProduct(input: CreateProductInput!): Product!
+}
+
 type Product @key(fields: "id") {
   id: ID!
   name: String!

--- a/services/products/src/resolvers.ts
+++ b/services/products/src/resolvers.ts
@@ -44,4 +44,15 @@ export const resolvers: Resolvers<ModelsContext & JwtContext> = {
       return prisma.user.findUnique({ where: { id } }).products()
     },
   },
+  MutatingUser: {
+    withProduct: ({ id }, { input: { name, sku } }, { prisma }) => {
+      return prisma.product.create({
+        data: {
+          name,
+          sku,
+          createdById: id,
+        },
+      })
+    },
+  },
 }

--- a/services/products/src/types/graphql.ts
+++ b/services/products/src/types/graphql.ts
@@ -20,6 +20,17 @@ export type CreateProductInput = {
   sku: Scalars['String'];
 };
 
+export type MutatingUser = {
+  __typename?: 'MutatingUser';
+  id: Scalars['ID'];
+  withProduct: Product;
+};
+
+
+export type MutatingUserWithProductArgs = {
+  input: CreateProductInput;
+};
+
 export type Product = {
   __typename?: 'Product';
   id: Scalars['ID'];
@@ -135,8 +146,9 @@ export type DirectiveResolverFn<TResult = {}, TParent = {}, TContext = {}, TArgs
 export type ResolversTypes = ResolversObject<{
   CreateProductInput: CreateProductInput;
   String: ResolverTypeWrapper<Scalars['String']>;
-  Product: ResolverTypeWrapper<Product>;
+  MutatingUser: ResolverTypeWrapper<MutatingUser>;
   ID: ResolverTypeWrapper<Scalars['ID']>;
+  Product: ResolverTypeWrapper<Product>;
   ProductVariant: ResolverTypeWrapper<ProductVariant>;
   Query: ResolverTypeWrapper<{}>;
   User: ResolverTypeWrapper<User>;
@@ -147,12 +159,20 @@ export type ResolversTypes = ResolversObject<{
 export type ResolversParentTypes = ResolversObject<{
   CreateProductInput: CreateProductInput;
   String: Scalars['String'];
-  Product: Product;
+  MutatingUser: MutatingUser;
   ID: Scalars['ID'];
+  Product: Product;
   ProductVariant: ProductVariant;
   Query: {};
   User: User;
   Boolean: Scalars['Boolean'];
+}>;
+
+export type MutatingUserResolvers<ContextType = any, ParentType extends ResolversParentTypes['MutatingUser'] = ResolversParentTypes['MutatingUser']> = ResolversObject<{
+  __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['MutatingUser']>, { __typename: 'MutatingUser' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
+
+  withProduct?: Resolver<ResolversTypes['Product'], { __typename: 'MutatingUser' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType, RequireFields<MutatingUserWithProductArgs, 'input'>>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
 export type ProductResolvers<ContextType = any, ParentType extends ResolversParentTypes['Product'] = ResolversParentTypes['Product']> = ResolversObject<{
@@ -185,6 +205,7 @@ export type UserResolvers<ContextType = any, ParentType extends ResolversParentT
 }>;
 
 export type Resolvers<ContextType = any> = ResolversObject<{
+  MutatingUser?: MutatingUserResolvers<ContextType>;
   Product?: ProductResolvers<ContextType>;
   ProductVariant?: ProductVariantResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;

--- a/services/users/schema.graphql
+++ b/services/users/schema.graphql
@@ -9,6 +9,12 @@ type User @key(fields: "id") {
   name: String
 }
 
+type MutatingUser @key(fields: "id") {
+  id: ID!
+  email: String
+  name: String
+}
+
 type JWT {
   token: String!
   refreshToken: String!
@@ -30,6 +36,6 @@ type Query {
 }
 
 type Mutation {
-  createUser(input: CreateUserInput!): User!
+  createUser(input: CreateUserInput!): MutatingUser!
   getToken(input: GetTokenInput): JWT
 }

--- a/services/users/src/types/graphql.ts
+++ b/services/users/src/types/graphql.ts
@@ -32,9 +32,16 @@ export type Jwt = {
   token: Scalars['String'];
 };
 
+export type MutatingUser = {
+  __typename?: 'MutatingUser';
+  email?: Maybe<Scalars['String']>;
+  id: Scalars['ID'];
+  name?: Maybe<Scalars['String']>;
+};
+
 export type Mutation = {
   __typename?: 'Mutation';
-  createUser: User;
+  createUser: MutatingUser;
   getToken?: Maybe<Jwt>;
 };
 
@@ -151,9 +158,10 @@ export type ResolversTypes = ResolversObject<{
   String: ResolverTypeWrapper<Scalars['String']>;
   GetTokenInput: GetTokenInput;
   JWT: ResolverTypeWrapper<Jwt>;
+  MutatingUser: ResolverTypeWrapper<MutatingUser>;
+  ID: ResolverTypeWrapper<Scalars['ID']>;
   Mutation: ResolverTypeWrapper<{}>;
   Product: ResolverTypeWrapper<Product>;
-  ID: ResolverTypeWrapper<Scalars['ID']>;
   Query: ResolverTypeWrapper<{}>;
   User: ResolverTypeWrapper<User>;
   Boolean: ResolverTypeWrapper<Scalars['Boolean']>;
@@ -165,9 +173,10 @@ export type ResolversParentTypes = ResolversObject<{
   String: Scalars['String'];
   GetTokenInput: GetTokenInput;
   JWT: Jwt;
+  MutatingUser: MutatingUser;
+  ID: Scalars['ID'];
   Mutation: {};
   Product: Product;
-  ID: Scalars['ID'];
   Query: {};
   User: User;
   Boolean: Scalars['Boolean'];
@@ -179,8 +188,16 @@ export type JwtResolvers<ContextType = any, ParentType extends ResolversParentTy
   __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
 }>;
 
+export type MutatingUserResolvers<ContextType = any, ParentType extends ResolversParentTypes['MutatingUser'] = ResolversParentTypes['MutatingUser']> = ResolversObject<{
+  __resolveReference?: ReferenceResolver<Maybe<ResolversTypes['MutatingUser']>, { __typename: 'MutatingUser' } & GraphQLRecursivePick<ParentType, {"id":true}>, ContextType>;
+  email?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  id?: Resolver<ResolversTypes['ID'], ParentType, ContextType>;
+  name?: Resolver<Maybe<ResolversTypes['String']>, ParentType, ContextType>;
+  __isTypeOf?: IsTypeOfResolverFn<ParentType, ContextType>;
+}>;
+
 export type MutationResolvers<ContextType = any, ParentType extends ResolversParentTypes['Mutation'] = ResolversParentTypes['Mutation']> = ResolversObject<{
-  createUser?: Resolver<ResolversTypes['User'], ParentType, ContextType, RequireFields<MutationCreateUserArgs, 'input'>>;
+  createUser?: Resolver<ResolversTypes['MutatingUser'], ParentType, ContextType, RequireFields<MutationCreateUserArgs, 'input'>>;
   getToken?: Resolver<Maybe<ResolversTypes['JWT']>, ParentType, ContextType, RequireFields<MutationGetTokenArgs, never>>;
 }>;
 
@@ -205,6 +222,7 @@ export type UserResolvers<ContextType = any, ParentType extends ResolversParentT
 
 export type Resolvers<ContextType = any> = ResolversObject<{
   JWT?: JwtResolvers<ContextType>;
+  MutatingUser?: MutatingUserResolvers<ContextType>;
   Mutation?: MutationResolvers<ContextType>;
   Product?: ProductResolvers<ContextType>;
   Query?: QueryResolvers<ContextType>;


### PR DESCRIPTION
Given a query like this:

```graphql
mutation CreateUser($input: CreateUserInput!, $productInput: CreateProductInput!) {
  createUser(input: $input) {
    email
    withProduct(input: $productInput) {
      name
      createdBy {
        email
      }
    }
  }
}
```

With variables like this:

```json
{
  "input": {
    "email": "user@example.com",
    "name": "User",
    "password": "Password"
  },
  "productInput": {
    "name": "Product Name",
    "sku": "12345"
  }
}
```

It creates a user and a product via federated services, returning a response like this:

```json
{
  "data": {
    "createUser": {
      "email": "user@example.com",
      "withProduct": {
        "name": "Product",
        "createdBy": {
          "email": "user@example.com"
        }
      }
    }
  }
}
```

Note that `CreateProductInput` was only defined in products subschema, and that `User` was extended there with the query field `withProduct(input: CreateProductInput!): Product!` as well.